### PR TITLE
fix: compute stats streaks from completions

### DIFF
--- a/internal/stats/engine.go
+++ b/internal/stats/engine.go
@@ -240,9 +240,60 @@ func computeTagClusters(tasks []core.Task) []TagCluster {
 }
 
 func computeStreaks(tasks []core.Task) StreakData {
+	completedDays := make(map[time.Time]struct{})
+	for _, task := range tasks {
+		if task.CompletedAt == nil {
+			continue
+		}
+		completedAt := task.CompletedAt.Local()
+		day := time.Date(completedAt.Year(), completedAt.Month(), completedAt.Day(), 0, 0, 0, 0, time.Local)
+		completedDays[day] = struct{}{}
+	}
+
+	if len(completedDays) == 0 {
+		return StreakData{Warning: false}
+	}
+
+	days := make([]time.Time, 0, len(completedDays))
+	for day := range completedDays {
+		days = append(days, day)
+	}
+	sort.Slice(days, func(i, j int) bool { return days[i].Before(days[j]) })
+
+	longest := 1
+	run := 1
+	for i := 1; i < len(days); i++ {
+		if days[i].Equal(days[i-1].AddDate(0, 0, 1)) {
+			run++
+		} else {
+			run = 1
+		}
+		if run > longest {
+			longest = run
+		}
+	}
+
+	now := time.Now().Local()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	current := streakEndingAt(completedDays, today)
+	if current == 0 {
+		current = streakEndingAt(completedDays, today.AddDate(0, 0, -1))
+	}
+
 	return StreakData{
-		Current: 5,
-		Longest: 12,
+		Current: current,
+		Longest: longest,
 		Warning: false,
 	}
+}
+
+func streakEndingAt(completedDays map[time.Time]struct{}, end time.Time) int {
+	streak := 0
+	for day := end; ; day = day.AddDate(0, 0, -1) {
+		if _, ok := completedDays[day]; !ok {
+			break
+		}
+		streak++
+	}
+	return streak
 }

--- a/internal/stats/engine_test.go
+++ b/internal/stats/engine_test.go
@@ -1,0 +1,82 @@
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/programmersd21/kairo/internal/core"
+)
+
+func completedTaskAt(t time.Time) core.Task {
+	return core.Task{CompletedAt: &t}
+}
+
+func localDay(t time.Time) time.Time {
+	lt := t.Local()
+	return time.Date(lt.Year(), lt.Month(), lt.Day(), 12, 0, 0, 0, time.Local)
+}
+
+func TestComputeStreaksEmpty(t *testing.T) {
+	got := computeStreaks(nil)
+	if got.Current != 0 || got.Longest != 0 || got.Warning {
+		t.Fatalf("computeStreaks(nil) = %+v, want zero streaks with no warning", got)
+	}
+}
+
+func TestComputeStreaksCountsMultipleTasksOnSameDayOnce(t *testing.T) {
+	now := time.Now()
+	today := localDay(now)
+	yesterday := today.AddDate(0, 0, -1)
+
+	got := computeStreaks([]core.Task{
+		completedTaskAt(today),
+		completedTaskAt(today.Add(2 * time.Hour)),
+		completedTaskAt(yesterday),
+	})
+
+	if got.Current != 2 || got.Longest != 2 {
+		t.Fatalf("computeStreaks duplicate day = %+v, want current=2 longest=2", got)
+	}
+}
+
+func TestComputeStreaksAllowsCurrentStreakThroughYesterday(t *testing.T) {
+	now := time.Now()
+	yesterday := localDay(now).AddDate(0, 0, -1)
+	twoDaysAgo := yesterday.AddDate(0, 0, -1)
+
+	got := computeStreaks([]core.Task{
+		completedTaskAt(twoDaysAgo),
+		completedTaskAt(yesterday),
+	})
+
+	if got.Current != 2 || got.Longest != 2 {
+		t.Fatalf("computeStreaks through yesterday = %+v, want current=2 longest=2", got)
+	}
+}
+
+func TestComputeStreaksCurrentIsZeroWhenLatestCompletionIsOlder(t *testing.T) {
+	old := localDay(time.Now()).AddDate(0, 0, -3)
+
+	got := computeStreaks([]core.Task{completedTaskAt(old)})
+
+	if got.Current != 0 || got.Longest != 1 {
+		t.Fatalf("computeStreaks stale completion = %+v, want current=0 longest=1", got)
+	}
+}
+
+func TestComputeStreaksLongestCanExceedCurrent(t *testing.T) {
+	today := localDay(time.Now())
+	yesterday := today.AddDate(0, 0, -1)
+	lastWeek := today.AddDate(0, 0, -7)
+
+	got := computeStreaks([]core.Task{
+		completedTaskAt(lastWeek),
+		completedTaskAt(lastWeek.AddDate(0, 0, 1)),
+		completedTaskAt(lastWeek.AddDate(0, 0, 2)),
+		completedTaskAt(yesterday),
+	})
+
+	if got.Current != 1 || got.Longest != 3 {
+		t.Fatalf("computeStreaks longest vs current = %+v, want current=1 longest=3", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #51 by replacing the hard-coded stats streak values with values computed from completed tasks.

The streak calculation now deduplicates multiple completions on the same calendar day, computes the longest consecutive run of completed-task days, and treats the current streak as active if it ends today or yesterday. That avoids showing `0` before the user has completed something today.

Added focused tests for empty task lists, duplicate completions on one day, yesterday-ending current streaks, stale streaks, and longest-vs-current behavior.

## Verification

- `gofmt -w internal/stats/engine.go internal/stats/engine_test.go`
- `git diff --check`
- `go test ./internal/stats ./internal/core ./internal/ui/stats` could not run locally because this environment has Go 1.22.2 and the repo requires Go 1.26; automatic toolchain download failed with `toolchain not available`.

## Summary by Sourcery

Compute task completion streaks dynamically from task data instead of using hard-coded values.

Bug Fixes:
- Derive current and longest streaks from unique completion days, allowing current streaks to span today or yesterday and handling stale streaks correctly.

Tests:
- Add focused unit tests covering empty task lists, duplicate completions on a single day, yesterday-ending streaks, stale streaks, and divergence between current and longest streaks.